### PR TITLE
removing the StatsBase dependency

### DIFF
--- a/src/Gillespie.jl
+++ b/src/Gillespie.jl
@@ -1,7 +1,6 @@
 module Gillespie
 
 using Distributions
-using StatsBase
 using DataFrames
 using Compat: UTF8String, view
 


### PR DESCRIPTION
removing the StatsBase dependency that is no longer needed for `sample()`