### PR TITLE
update UTF8String to String

### DIFF
--- a/src/Gillespie.jl
+++ b/src/Gillespie.jl
@@ -2,7 +2,7 @@ module Gillespie
 
 using Distributions
 using DataFrames
-using Compat: UTF8String, view
+using Compat: view
 
 export
     ssa,

--- a/src/SSA.jl
+++ b/src/SSA.jl
@@ -5,7 +5,7 @@
 
 "
 type SSAStats
-    termination_status::UTF8String
+    termination_status::String
     nsteps::Int64
 end
 


### PR DESCRIPTION
Hey @sdwfrost,

I got some warnings because Compat.UTF8String is deprecated here is a patch.

SSAStats.termination_status was a UTF8String, which is now called String.