### PR TITLE
Explicitly create DataFrame

### DIFF
--- a/src/SSA.jl
+++ b/src/SSA.jl
@@ -338,5 +338,10 @@ end
 
 "This takes a single argument of type `SSAResult` and returns a `DataFrame`."
 function ssa_data(s::SSAResult)
-    hcat(DataFrame(time=s.time),convert(DataFrame,s.data))
+    # ERROR: LoadError: MethodError: Cannot `convert` an object of type Matrix{Int64} to an object of type DataFrames.DataFrame
+    # hcat(DataFrame(time=s.time),convert(DataFrame,s.data))
+    hcat(
+        DataFrame(time=s.time),
+        DataFrame(s.data, :auto),
+    )
 end


### PR DESCRIPTION
The example in the README would fail with:

```
ERROR: LoadError: MethodError: Cannot `convert` an object of type Matrix{Int64} to an object of type DataFrames.DataFrame

Closest candidates are:
  convert(::Type{DataFrames.DataFrame}, ::DataFrames.SubDataFrame)
   @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/subdataframe/subdataframe.jl:319
  convert(::Type{T}, ::T) where T
   @ Base Base.jl:84
  DataFrames.DataFrame(::Matrix)
   @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/dataframe/dataframe.jl:400
  ...

at ``Gillespie.ssa_data()`` . 

